### PR TITLE
fix: prevent daemon hang on stale FIFO

### DIFF
--- a/hypr-sticky-hdr
+++ b/hypr-sticky-hdr
@@ -561,10 +561,11 @@ handle_command() {
 
 run_daemon() {
     if [[ -p "$CMD_FIFO" ]]; then
-        if echo "CMD:status:" > "$CMD_FIFO" 2>/dev/null; then
+        if timeout 2 bash -c "echo 'CMD:status:' > '$CMD_FIFO'" 2>/dev/null; then
             log "Daemon already running. Remove $CMD_FIFO to force."
             exit 1
         fi
+        log "Removing stale FIFO from previous run"
     fi
 
     rm -f "$CMD_FIFO"
@@ -592,7 +593,7 @@ run_daemon() {
         done
         wait 2>/dev/null || true
     }
-    trap 'cleanup; exit 0' INT TERM
+    trap 'cleanup; exit 0' INT TERM HUP QUIT PIPE
     trap 'cleanup' EXIT
 
     parse_config_file


### PR DESCRIPTION
## Summary

Fixes #1

- Wrap FIFO liveness check in `timeout 2` so a stale pipe (no reader) is detected and removed instead of blocking forever
- Trap additional signals (`HUP`, `QUIT`, `PIPE`) for cleanup on more exit paths
- `kill -9` / OOM / crash can't be caught, but the stale FIFO is now safely handled on next startup

## Test plan

- [ ] Kill a running daemon with `kill -9`, then start a new one — should start normally after 2s
- [ ] Start daemon normally, Ctrl+C — FIFO should be cleaned up
- [ ] Start daemon when one is already running — should print "already running" and exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)