### PR TITLE
fix: auto-detect active Hyprland instance

### DIFF
--- a/hypr-sticky-hdr
+++ b/hypr-sticky-hdr
@@ -52,7 +52,35 @@ CONFIG_MTIME=""
 
 CMD_FIFO="/tmp/hypr-sticky-hdr-${UID}.fifo"
 REPLY_DIR="/tmp/hypr-sticky-hdr-${UID}-replies"
-HYPR_SOCKET="/run/user/${UID}/hypr/${HYPRLAND_INSTANCE_SIGNATURE}/.socket2.sock"
+
+# Auto-detect active Hyprland instance: pick the socket dir with a live socket,
+# preferring the newest if multiple exist. Falls back to HYPRLAND_INSTANCE_SIGNATURE.
+_detect_hypr_instance() {
+    local hypr_dir="/run/user/${UID}/hypr"
+    local best="" best_mtime=0
+    for d in "$hypr_dir"/*/; do
+        [[ -S "${d}.socket2.sock" ]] || continue
+        local mtime
+        mtime=$(stat -c %Y "${d}.socket2.sock" 2>/dev/null) || continue
+        if [[ "$mtime" -gt "$best_mtime" ]]; then
+            best="${d}.socket2.sock"
+            best_mtime="$mtime"
+        fi
+    done
+    if [[ -n "$best" ]]; then
+        echo "$best"
+    elif [[ -n "$HYPRLAND_INSTANCE_SIGNATURE" ]]; then
+        echo "$hypr_dir/${HYPRLAND_INSTANCE_SIGNATURE}/.socket2.sock"
+    else
+        return 1
+    fi
+}
+
+HYPR_SOCKET="$(_detect_hypr_instance)" || { echo "Cannot find Hyprland socket" >&2; exit 1; }
+
+# Update HYPRLAND_INSTANCE_SIGNATURE so hyprctl uses the detected instance
+HYPRLAND_INSTANCE_SIGNATURE="$(basename "$(dirname "$HYPR_SOCKET")")"
+export HYPRLAND_INSTANCE_SIGNATURE
 
 # --- Helpers -----------------------------------------------------------------
 

--- a/hypr-sticky-hdr
+++ b/hypr-sticky-hdr
@@ -53,9 +53,9 @@ CONFIG_MTIME=""
 CMD_FIFO="/tmp/hypr-sticky-hdr-${UID}.fifo"
 REPLY_DIR="/tmp/hypr-sticky-hdr-${UID}-replies"
 
-# Auto-detect active Hyprland instance: pick the socket dir with a live socket,
+# Auto-detect active Hyprland socket: pick the socket dir with a live socket,
 # preferring the newest if multiple exist. Falls back to HYPRLAND_INSTANCE_SIGNATURE.
-_detect_hypr_instance() {
+_detect_hypr_socket() {
     local hypr_dir="/run/user/${UID}/hypr"
     local best="" best_mtime=0
     for d in "$hypr_dir"/*/; do
@@ -76,11 +76,7 @@ _detect_hypr_instance() {
     fi
 }
 
-HYPR_SOCKET="$(_detect_hypr_instance)" || { echo "Cannot find Hyprland socket" >&2; exit 1; }
-
-# Update HYPRLAND_INSTANCE_SIGNATURE so hyprctl uses the detected instance
-HYPRLAND_INSTANCE_SIGNATURE="$(basename "$(dirname "$HYPR_SOCKET")")"
-export HYPRLAND_INSTANCE_SIGNATURE
+HYPR_SOCKET=""
 
 # --- Helpers -----------------------------------------------------------------
 
@@ -588,6 +584,10 @@ handle_command() {
 # --- Daemon ------------------------------------------------------------------
 
 run_daemon() {
+    HYPR_SOCKET="$(_detect_hypr_socket)" || { echo "Cannot find Hyprland socket" >&2; exit 1; }
+    HYPRLAND_INSTANCE_SIGNATURE="$(basename "$(dirname "$HYPR_SOCKET")")"
+    export HYPRLAND_INSTANCE_SIGNATURE
+
     if [[ -p "$CMD_FIFO" ]]; then
         if timeout 2 bash -c "echo 'CMD:status:' > '$CMD_FIFO'" 2>/dev/null; then
             log "Daemon already running. Remove $CMD_FIFO to force."


### PR DESCRIPTION
## Summary

- Auto-detect the active Hyprland socket instead of relying on `$HYPRLAND_INSTANCE_SIGNATURE` env var
- Scans `/run/user/$UID/hypr/` for the newest live `.socket2.sock`
- Exports corrected `HYPRLAND_INSTANCE_SIGNATURE` so all `hyprctl` calls use the right instance
- Falls back to the env var if no live sockets are found

Fixes #3

## Test plan

- [x] Verified daemon starts with stale `HYPRLAND_INSTANCE_SIGNATURE` in shell
- [x] Verified correct instance detected when multiple instance dirs exist
- [ ] Verify fallback works when only one instance exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)